### PR TITLE
Updated installation method for {atm} and {surveyR} packages

### DIFF
--- a/Archive/plotBio_All.Rmd
+++ b/Archive/plotBio_All.Rmd
@@ -12,6 +12,7 @@ css: css/ast.css
 ```{r setup,echo=F,message=F,warning=F,error=F,include=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,raster,cowplot,DBI,odbc,RSQLite,scatterpie,ggspatial,vroom,
@@ -21,10 +22,11 @@ pacman::p_load(tidyverse,raster,cowplot,DBI,odbc,RSQLite,scatterpie,ggspatial,vr
                lwgeom,htmlwidgets)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-# atm
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")

--- a/Archive/plotBio_Web.Rmd
+++ b/Archive/plotBio_Web.Rmd
@@ -10,6 +10,7 @@ css: css/ast.css
 ```{r setup,echo=F,message=F,warning=F,error=F,include=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,raster,cowplot,DBI,odbc,RSQLite,scatterpie,ggspatial,vroom,
@@ -19,13 +20,10 @@ pacman::p_load(tidyverse,raster,cowplot,DBI,odbc,RSQLite,scatterpie,ggspatial,vr
                lwgeom,htmlwidgets)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-# atm
-pacman::p_load_gh("kstierhoff/atm")
-# rnaturalearth data
-pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
-pacman::p_load_gh("ropenscilabs/rnaturalearthhires")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Define method of table generation (whether kable or xtable) for best formatting
 doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')

--- a/Archive/reportMSR-Mexico.Rmd
+++ b/Archive/reportMSR-Mexico.Rmd
@@ -7,6 +7,7 @@ output: html_document
 ```{r set-up, error=FALSE, message=FALSE, warning=FALSE, echo=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,leafem,
@@ -14,10 +15,10 @@ pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,leafem,
                odbc,kableExtra,rnaturalearth,shadowtext,here,fs,ggspatial)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
-
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Define method of table generation (whether kable or xtable) for best formatting
 doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')

--- a/Code/extract_CPS_NASC.R
+++ b/Code/extract_CPS_NASC.R
@@ -16,10 +16,10 @@ if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse, here, fs)
+
 # Install and load required packages from Github -------------------------------
+if (!require("atm")) pkg_install("SWFSC/atm")
 pacman::p_load_gh("kstierhoff/atm")
-# If pacman fails, use pak instead
-# pak::pkg_install("kstierhoff/atm")
 
 # Close any open graphics windows
 graphics.off()

--- a/Code/get_nav_scs.R
+++ b/Code/get_nav_scs.R
@@ -2,7 +2,6 @@
 
 # # Load libraries
 # pacman::p_load(tidyverse, here, lubridate, fs)
-# pacman::p_load_gh("kstierhoff/surveyR")
 # 
 # # SCS data file info
 # scs.nav.path    <- "C:/SURVEY/2207RL/DATA/SCS" # Local

--- a/Code/plot_purseSeine_2207RL.R
+++ b/Code/plot_purseSeine_2207RL.R
@@ -3,14 +3,17 @@
 
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,readr, lubridate, here, plotly, sf, mapview)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 
 # Get project settings----------------------------------------------------------
 # Get project name from directory

--- a/Code/plot_purseSeine_2307RL.R
+++ b/Code/plot_purseSeine_2307RL.R
@@ -3,14 +3,16 @@
 
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,readr, lubridate, here, plotly, sf, mapview)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Get project settings----------------------------------------------------------
 # Get project name from directory

--- a/Code/plot_purseSeine_2407RL.R
+++ b/Code/plot_purseSeine_2407RL.R
@@ -3,14 +3,16 @@
 
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,readr, lubridate, here, plotly, sf, mapview)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Get project settings----------------------------------------------------------
 # Get project name from directory

--- a/Code/processSeine_2207RL.R
+++ b/Code/processSeine_2207RL.R
@@ -3,14 +3,16 @@
 
 # # Install and load pacman (library management package)
 # if (!require("pacman")) install.packages("pacman")
-# 
+# if (!require("pak")) install.packages("pak")
+
 # # Install and load required packages from CRAN ---------------------------------
 # pacman::p_load(tidyverse,readr, lubridate, here, plotly, sf, mapview)
 # 
 # # Install and load required packages from Github -------------------------------
-# # surveyR
-# pacman::p_load_gh("kstierhoff/surveyR")
-# pacman::p_load_gh("kstierhoff/atm")
+# if (!require("atm")) pkg_install("SWFSC/atm")
+# if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+# pacman::p_load_gh("SWFSC/atm")
+# pacman::p_load_gh("SWFSC/surveyR")
 # 
 # # Get project settings----------------------------------------------------------
 # # Get project name from directory

--- a/Code/processSeine_2307RL.R
+++ b/Code/processSeine_2307RL.R
@@ -2,15 +2,18 @@
 # Source following the section entitled estimateNearshore in estimateBiomass ----
 
 # # Install and load pacman (library management package)
+# # Install and load pacman (library management package)
 # if (!require("pacman")) install.packages("pacman")
-# 
+# if (!require("pak")) install.packages("pak")
+
 # # Install and load required packages from CRAN ---------------------------------
-# pacman::p_load(tidyverse,readr, lubridate, here, plotly, sf, mapview, readxl)
+# pacman::p_load(tidyverse,readr, lubridate, here, plotly, sf, mapview)
 # 
 # # Install and load required packages from Github -------------------------------
-# # surveyR
-# pacman::p_load_gh("kstierhoff/surveyR")
-# pacman::p_load_gh("kstierhoff/atm")
+# if (!require("atm")) pkg_install("SWFSC/atm")
+# if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+# pacman::p_load_gh("SWFSC/atm")
+# pacman::p_load_gh("SWFSC/surveyR")
 # 
 # # Get project settings----------------------------------------------------------
 # # Get project name from directory

--- a/Code/scs2gps.R
+++ b/Code/scs2gps.R
@@ -1,8 +1,17 @@
 # Create gps.csv file for Echoview processing from SCS data
 
+# Install and load pacman (library management package)
+if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
+
 # Load libraries
 pacman::p_load(tidyverse, here, lubridate, fs)
-pacman::p_load_gh("kstierhoff/surveyR")
+
+# Install and load required packages from Github -------------------------------
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Specify nav file source
 # nav.path <- "U:/SURVEYS/20220627_LASKER_SummerCPS/DATA/SCS/AST CONTINUOUS" # At sea

--- a/Doc/checkTransects.Rmd
+++ b/Doc/checkTransects.Rmd
@@ -12,6 +12,7 @@ output:
 # Install and Load packages
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,sf,mapview,lubridate,here,knitr,DT,bookdown,
@@ -20,9 +21,10 @@ pacman::p_load(tidyverse,sf,mapview,lubridate,here,knitr,DT,bookdown,
                shadowtext,stplanr,tmaptools)
 
 # Install and load required packages from Github -------------------------------
-pacman::p_load_gh("rstudio/distill")
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")

--- a/Doc/checkTrawls.Rmd
+++ b/Doc/checkTrawls.Rmd
@@ -15,6 +15,7 @@ csl: csl/ices-journal-of-marine-science.csl
 ```{r set-up,echo=F,message=F,warning=F,error=F,include=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,plotly,lubridate,mapview,kableExtra,leaflet,
@@ -22,8 +23,10 @@ pacman::p_load(tidyverse,plotly,lubridate,mapview,kableExtra,leaflet,
                cowplot)
 
 # Install and load required packages from Github -------------------------------
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Define method of table generation (whether kable or xtable) for best formatting
 doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')

--- a/Doc/estimateBiomass.Rmd
+++ b/Doc/estimateBiomass.Rmd
@@ -25,6 +25,7 @@ editor_options:
 ```{r load-libraries-functions, error=FALSE, message=FALSE, warning=FALSE, echo=FALSE}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,swfscMisc,reshape2,tcltk,lubridate,sp,readxl,
@@ -39,9 +40,11 @@ pacman::p_load(tidyverse,swfscMisc,reshape2,tcltk,lubridate,sp,readxl,
 # install_version("ggrepel", version = "0.9.4", repos = "http://cran.us.r-project.org")
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")

--- a/Doc/makeTransects.Rmd
+++ b/Doc/makeTransects.Rmd
@@ -12,6 +12,7 @@ output:
 # Install and Load packages
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,swfscMisc,sf,mapview,lubridate,here,
@@ -19,9 +20,11 @@ pacman::p_load(tidyverse,swfscMisc,sf,mapview,lubridate,here,
                pgirmess,bookdown,fs,rnaturalearth,
                fs,concaveman,gt)
 
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+# Install and load required packages from Github -------------------------------
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Set global knitr chunk options
 if (.Platform$OS.type == "unix") {

--- a/Doc/plotCSV.Rmd
+++ b/Doc/plotCSV.Rmd
@@ -19,12 +19,14 @@ pacman::p_load(tidyverse,lubridate,here,sf,knitr,fs,leaflet,leaflet.extras,bookd
                leafem,mapview,htmltools,rnaturalearth,stplanr,ggrepel,plotly, kableExtra)
 
 # Install and load required packages from Github -------------------------------
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")
-# atm
-pacman::p_load_gh("kstierhoff/atm")
-pacman::p_load_gh("kstierhoff/surveyR")
 
 # determines method of table generation (whether kable or xtable) for best formatting
 doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')

--- a/Doc/plotCTD.Rmd
+++ b/Doc/plotCTD.Rmd
@@ -13,6 +13,7 @@ css: css/ast.css
 ```{r setup,echo=FALSE,warning=FALSE,message=FALSE,include=FALSE}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,cowplot,knitr,shadowtext,plotly,sf,fs,vroom,leaflet,
@@ -20,10 +21,11 @@ pacman::p_load(tidyverse,cowplot,knitr,shadowtext,plotly,sf,fs,vroom,leaflet,
                DT,mapview,bookdown,ggspatial,leafem,leaflet.extras)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-# atm
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")

--- a/Doc/plotCUFES.Rmd
+++ b/Doc/plotCUFES.Rmd
@@ -10,6 +10,7 @@ css: css/ast.css
 ```{r setup,echo=F,message=F,warning=F,error=F,include=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,raster,cowplot,DBI,odbc,RSQLite,scatterpie,ggspatial,vroom,
@@ -19,10 +20,11 @@ pacman::p_load(tidyverse,raster,cowplot,DBI,odbc,RSQLite,scatterpie,ggspatial,vr
                lwgeom,rayshader)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-# atm
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")

--- a/Doc/plotSaildrone.Rmd
+++ b/Doc/plotSaildrone.Rmd
@@ -8,15 +8,17 @@ output: html_document
 ```{r setup, include=FALSE}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,lubridate,here,fs,sf,mapview,DT,lwgeom)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-# atm
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")

--- a/Doc/plotSurvey.Rmd
+++ b/Doc/plotSurvey.Rmd
@@ -11,6 +11,7 @@ css: css/ast.css
 ```{r setup,echo=F,message=F,warning=F,error=F,include=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,raster,cowplot,DBI,odbc,RSQLite,scatterpie,ggspatial,vroom,
@@ -20,10 +21,11 @@ pacman::p_load(tidyverse,raster,cowplot,DBI,odbc,RSQLite,scatterpie,ggspatial,vr
                lwgeom,htmlwidgets)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-# atm
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")

--- a/Doc/plotTrawls.Rmd
+++ b/Doc/plotTrawls.Rmd
@@ -15,6 +15,7 @@ csl: csl/ices-journal-of-marine-science.csl
 ```{r set-up,echo=F,message=F,warning=F,error=F,include=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,plotly,lubridate,here,odbc,DBI,glue,
@@ -22,8 +23,10 @@ pacman::p_load(tidyverse,plotly,lubridate,here,odbc,DBI,glue,
                patchwork)
 
 # Install and load required packages from Github -------------------------------
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Knitr options
 knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE,

--- a/Doc/presentBiomass.Rmd
+++ b/Doc/presentBiomass.Rmd
@@ -10,6 +10,7 @@ output:
 ```{r load-libraries,echo=F,error=F,message=F,warning=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate, knitr,here,
@@ -17,8 +18,10 @@ pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate, knitr,here,
                mapview)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # set system time zone to UTC
 Sys.setenv(tz = "UTC")

--- a/Doc/reportBiomass_2307RL.Rmd
+++ b/Doc/reportBiomass_2307RL.Rmd
@@ -35,6 +35,7 @@ linkcolor: blue
 ```{r load-libraries,echo=F,error=F,message=F,warning=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate,knitr,here,
@@ -42,9 +43,10 @@ pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate,knitr,here,
                odbc,cowplot,mapview,fs,patchwork,gt)
 
 # Install and load required packages from Github -------------------------------
-# AST packages
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # kableExtra - for R >= 4.3.0
 pacman::p_load_gh("kupietz/kableExtra")

--- a/Doc/reportBiomass_2407RL.Rmd
+++ b/Doc/reportBiomass_2407RL.Rmd
@@ -35,6 +35,7 @@ linkcolor: blue
 ```{r load-libraries,echo=F,error=F,message=F,warning=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate,knitr,here,
@@ -42,9 +43,10 @@ pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate,knitr,here,
                odbc,cowplot,mapview,fs,patchwork,gt)
 
 # Install and load required packages from Github -------------------------------
-# AST packages
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # kableExtra - for R >= 4.3.0
 pacman::p_load_gh("kupietz/kableExtra")

--- a/Doc/reportCatch_CDFW-MOU.Rmd
+++ b/Doc/reportCatch_CDFW-MOU.Rmd
@@ -12,6 +12,7 @@ css: css/ast.css
 ```{r set-up, error=FALSE, message=FALSE, warning=FALSE, echo=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,
@@ -20,10 +21,10 @@ pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,
                ggspatial,janitor,DT)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
-
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Define method of table generation (whether kable or xtable) for best formatting
 doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')

--- a/Doc/reportCatch_CDFW-SCP.Rmd
+++ b/Doc/reportCatch_CDFW-SCP.Rmd
@@ -12,6 +12,7 @@ css: css/ast.css
 ```{r set-up, error=FALSE, message=FALSE, warning=FALSE, echo=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,
@@ -20,10 +21,10 @@ pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,
                ggspatial,janitor,DT)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
-
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Define method of table generation (whether kable or xtable) for best formatting
 doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')

--- a/Doc/reportCatch_ODFW.Rmd
+++ b/Doc/reportCatch_ODFW.Rmd
@@ -12,6 +12,7 @@ css: css/ast.css
 ```{r set-up, error=FALSE, message=FALSE, warning=FALSE, echo=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,leafem,
@@ -20,10 +21,10 @@ pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,leafem,
                RSQLite,DT)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
-
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # Define method of table generation (whether kable or xtable) for best formatting
 doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')

--- a/Doc/reportCatch_ONMS.Rmd
+++ b/Doc/reportCatch_ONMS.Rmd
@@ -16,6 +16,7 @@ bibliography: bib/ast_bib.bib
 ```{r load-libraries,echo=F,error=F,message=F,warning=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate, knitr,here,
@@ -23,9 +24,10 @@ pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate, knitr,here,
                odbc,cowplot,mapview,fs,sf)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # determines method of table generation (whether kable or xtable) for best formatting
 doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')

--- a/Doc/reportCatch_WCRO.Rmd
+++ b/Doc/reportCatch_WCRO.Rmd
@@ -10,6 +10,7 @@ output:
 ```{r load-libraries,echo=F,error=F,message=F,warning=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate, knitr,here,
@@ -17,9 +18,10 @@ pacman::p_load(tidyverse,grid,gridExtra,pander,flextable,lubridate, knitr,here,
                odbc,cowplot,mapview,fs,sf,rnaturalearth,ggspatial)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 # determines method of table generation (whether kable or xtable) for best formatting
 doc.type <- knitr::opts_knit$get('rmarkdown.pandoc.to')

--- a/Doc/reportCatch_WDFW.Rmd
+++ b/Doc/reportCatch_WDFW.Rmd
@@ -12,6 +12,7 @@ css: css/ast.css
 ```{r set-up, error=FALSE, message=FALSE, warning=FALSE, echo=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,leafem,
@@ -20,9 +21,10 @@ pacman::p_load(tidyverse,swfscMisc,lubridate,sp,mapview,RODBC,leafem,
                janitor,DT)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
 
 
 # Define method of table generation (whether kable or xtable) for best formatting

--- a/Doc/reportEC-ITA.Rmd
+++ b/Doc/reportEC-ITA.Rmd
@@ -12,6 +12,7 @@ output:
 ```{r setup, include=FALSE}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,swfscMisc,lubridate,cowplot,here,marmap,fs,sf, odbc,
@@ -19,10 +20,11 @@ pacman::p_load(tidyverse,swfscMisc,lubridate,cowplot,here,marmap,fs,sf, odbc,
                rnaturalearth,ggspatial,kableExtra,geosphere,janitor,DT)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-# atm==
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")

--- a/Doc/reportMSR-Canada.Rmd
+++ b/Doc/reportMSR-Canada.Rmd
@@ -8,6 +8,7 @@ output: html_document
 ```{r load-libraries-functions, error=FALSE, message=FALSE, warning=FALSE, echo=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,lubridate,knitr,maps,rnaturalearth,
@@ -16,9 +17,11 @@ pacman::p_load(tidyverse,lubridate,knitr,maps,rnaturalearth,
                data.table,xts,mapproj)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")

--- a/Doc/reportMSR-Mexico.Rmd
+++ b/Doc/reportMSR-Mexico.Rmd
@@ -8,6 +8,7 @@ output: html_document
 ```{r load-libraries-functions, error=FALSE, message=FALSE, warning=FALSE, echo=F}
 # Install and load pacman (library management package)
 if (!require("pacman")) install.packages("pacman")
+if (!require("pak")) install.packages("pak")
 
 # Install and load required packages from CRAN ---------------------------------
 pacman::p_load(tidyverse,lubridate,knitr,maps,rnaturalearth,
@@ -16,9 +17,11 @@ pacman::p_load(tidyverse,lubridate,knitr,maps,rnaturalearth,
                data.table,xts,mapproj)
 
 # Install and load required packages from Github -------------------------------
-# surveyR
-pacman::p_load_gh("kstierhoff/surveyR")
-pacman::p_load_gh("kstierhoff/atm")
+if (!require("atm")) pkg_install("SWFSC/atm")
+if (!require("surveyR")) pkg_install("SWFSC/surveyR")
+pacman::p_load_gh("SWFSC/atm")
+pacman::p_load_gh("SWFSC/surveyR")
+
 # rnaturalearth data
 pacman::p_load_gh("ropenscilabs/rnaturalearthdata")
 pacman::p_load_gh("ropenscilabs/rnaturalearthhires")


### PR DESCRIPTION
Updated much of the code that relies on the {atm} and {surveyR} packages, which reside on the SWFSC enterprise and do not properly install using devtools or remotes or pacman::p_load_gh().