### PR TITLE
Update sound speed and absorption calculation section

### DIFF
--- a/Doc/bib/ast_bib.bib
+++ b/Doc/bib/ast_bib.bib
@@ -61,6 +61,15 @@
   type    = {Journal Article},
 }
 
+@Article{Bodholt2002,
+  author       = {Bodholt, H.},
+  title        = {The effect of water temperature and salinity on echo sounder measurements},
+  number       = {123},
+  date         = {2002},
+  journaltitle = {ICES Symposium on Acoustics in Fisheries},
+  type         = {Journal Article},
+}
+
 @Article{Brandon2004,
   author    = {Brandon, M. A. and Naganobu, M. and Demer, D. A. and Chernyshkov, P. and Trathan, P. N. and Thorpe, S. E. and Kameda, T. and Berezhinskiy, O. A. and Hawker, E. J. and Grant, S.},
   title     = {Physical oceanography in the Scotia Sea during the CCAMLR 2000 survey, austral summer 2000},

--- a/Doc/reportBiomass_2407RL.Rmd
+++ b/Doc/reportBiomass_2407RL.Rmd
@@ -592,18 +592,33 @@ include_graphics(here("Figs/fig_trawl_seine_sets_comp.png"))
 
 The calibrated echosounder data from each transect were processed using commercial software ([Echoview](https://www.echoview.com/) `r ev.version`; Echoview Software Pty Ltd.) and estimates of the sound speed and absorption coefficient calculated with contemporaneous data from CTD probes cast while stationary or underway (UCTD, see **Section \@ref(methods-ctd-sampling)**). Data collected along the daytime transects at speeds $\geq$ 5 kn were used to estimate CPS densities. Nighttime acoustic data were not used for biomass estimations because they are assumed to be negatively biased due to diel-vertical migration and disaggregation of the target species’ schools [@Cutter2008].  
 
-### Sound speed and absorption calculation {#methods-sound-calcs}  
+### Sound speed and absorption compensation {#methods-sound-calcs}  
 
 **Update this section to describe the sound speed profiles applied in Echoview**
 
-Pressure measured in CTD casts was used to derive depths averaged in 1-m bins. Sound speed in each bin ($c_{w,i}$, m s^-1^) was estimated from the average salinity, density, and pH [if measured, else pH = 8; @Chen1977; @Seabird2013]. The harmonic sound speed in the water column ($\overline{c}_w$, m s^-1^) was calculated over the upper 70 m as:  
+CTD casts provide measures of pressure, conductivity, and temperature, from which depth, salinity, and sound speed ($c_{w,i}$, m s^-1^) are derived. On _Lasker_, the underway CTD probe (RapidPro Plus; Valeport) provided pre-processed data containing temperature and derived measures of depth, salinity, and $c_{w}$. On _Lisa Marie_, the CTD probe (SBE19plus; Seabird) provided raw measures of pressure, conductivity, and temperature, for which post-processing software (Seabird SBEDataProcessing) was used to filter the data, derive depth, average into 1-m bins, then derive salinity and $c_{w}$ for each bin. For both probes, values of depth and $c_{w}$ for the downcast were defined in transect-specific Echoview Calibration Supplement (ECS) files utilized for the Echoview data processing. The $c_{w}$ profile is used to estimate ranges to the sound scatterers and to compensate the echo signal for spherical spreading and attenuation during propagation of the sound pulse from the transducer to the scatterer range and back [@Simmonds2005]. Similarly, the average temperature, salinity, and depth, along with the harmonic mean of $c_{w}$, were computed over the entire downcast and defined in the ECS file. These averaged values are used by Echoview to calculate absorption coefficients which account for frequency-dependent absorption losses. Lastly, the calibration parameters were updated to compensate for changes in local $c_{w}$ relative to that at the time of the calibration [@Bodholt2002]:
 
 \begin{equation}
-\overline{c}_w = \frac{\sum_{i=1}^{N} \Delta r_i}{\sum_{i=1}^{N} \Delta r_i/c_{w,i}}\text{,}
-(\#eq:time-avg-sound-speed)
+G_0=G_0^{'}+20log_{10}\left(\frac{c_w^{'}}{c_w}\right)\text{,}
+(\#eq:compensate-gain-sound-speed)
 \end{equation}
 
-where $\Delta r$ is the depth of increment $i$ [@Seabird2013]. Measurements of seawater temperature ($t_w$, $^{\circ}\textrm{C}$), salinity ($s_w$, psu), depth, pH, and $\overline{c}_w$ are also used to calculate the mean absorption coefficients ($\overline{\alpha}_a$, dB m^-1^) over species-specific portion of the profile, using equations in Francois and Garrison [-@Francois1982a], Ainslie and McColm [-@Ainslie1998], and Doonan et al. [-@Doonan2003]. Both $\overline{c}_w$ and $\overline{\alpha}_a$ are later used to estimate ranges to the sound scatterers to compensate the echo signal for spherical spreading and attenuation during propagation of the sound pulse from the transducer to the scatterer range and back [@Simmonds2005]. The CTD rosette, when cast, also provides measures of fluorescence and dissolved oxygen concentration versus depth, which may be used to estimate the vertical dimension of Pacific Sardine potential habitat [@Zwolinski2011], particularly the depth of the upper-mixed layer where most epipelagic CPS reside. The latter information is used to inform echo classification (see **Section \@ref(methods-echo-classification)**).  
+\begin{equation}
+\Psi=\Psi^{'}+20log_{10}\left(\frac{c_w}{c_w^{'}}\right)\text{,}
+(\#eq:compensate-EBA-sound-speed)
+\end{equation}
+
+\begin{equation}
+\alpha_\mathrm{-3dB}=\alpha_\mathrm{-3dB}^{'}*\left(\frac{c_w}{c_w^{'}}\right)\text{,}
+(\#eq:compensate-AlongBW-sound-speed)
+\end{equation}
+
+\begin{equation}
+\beta_\mathrm{-3dB}=\beta_\mathrm{-3dB}^{'}*\left(\frac{c_w}{c_w^{'}}\right)\text{,}
+(\#eq:compensate-AthwtBW-sound-speed)
+\end{equation}
+
+where the prime symbol denotes values from the calibration and $c_{w}$ is at the depth of the transducer. The CTD rosette, when cast, also provides measures of fluorescence and dissolved oxygen concentration versus depth, which may be used to estimate the vertical dimension of Pacific Sardine potential habitat [@Zwolinski2011], particularly the depth of the upper-mixed layer where most epipelagic CPS reside. The latter information is used to inform echo classification (see **Section \@ref(methods-echo-classification)**).  
 
 ### Echo classification {#methods-echo-classification}  
 


### PR DESCRIPTION
Updated the section describing how the sound speed and absorption values are derived from the (u)CTD casts, which is now different since instead of calculating averaged values we now input a sound speed profile into the ECS files used by Echoview. Also added detail about how the calibration parameters are updated for changes in sound speed.